### PR TITLE
docs: add openssf best practices badge, comment out version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # OWASP Domain Protect
-[![Version](https://img.shields.io/github/v/release/domain-protect/domain-protect)](https://github.com/domain-protect/domain-protect/releases/tag/0.1.0)
+<!--
+[![Version](https://img.shields.io/github/v/release/domain-protect/terraform-aws-domain-protect)](https://github.com/domain-protect/terraform-aws-domain-protect/releases/tag/0.1.0)
+-->
+
 [![Python 3.x](https://img.shields.io/badge/Python-3.x-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 ![OWASP Maturity](https://img.shields.io/badge/owasp-incubator%20project-53AAE5.svg)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/domain-protect/terraform-aws-domain-protect/badge)](https://scorecard.dev/viewer/?uri=github.com/domain-protect/terraform-aws-domain-protect)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9420/badge)](https://www.bestpractices.dev/projects/9420)
 
 ## Unreleased
 


### PR DESCRIPTION
## what
- docs: add openssf best practices badge, comment out version

## why
- Add the badge to improve our score
- Add the badge to showcase our progress and commitment to security
- Comment out the version since there is no version in this repo and the badge currently points to the previous repo

## references
- https://www.bestpractices.dev/projects/9420