### PR TITLE
chore: add a pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,3 @@
 - Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
 - Use `closes #123`, if this PR closes a GitHub issue `#123`
 -->
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 ## why
 <!--
-- Provide the justifications for the changes (e.g. business case). 
+- Provide the justifications for the changes (e.g. business case).
 - Describe why these changes were made (e.g. why do these commits fix the problem?)
 - Use bullet points to be concise and to the point.
 -->
@@ -15,7 +15,7 @@
 
 ## references
 <!--
-- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
 - Use `closes #123`, if this PR closes a GitHub issue `#123`
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## what
+<!--
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+-->
+
+
+## why
+<!--
+- Provide the justifications for the changes (e.g. business case). 
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+-->
+
+
+## references
+<!--
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->
+


### PR DESCRIPTION
## what
- chore: add a pr template

## why
- PR templates are nice to prompt the user on what they did, why did they did it, and what notable references got them to the proposed solution

## references
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#best-practices-for-managing-pull-requests
