### PR TITLE
chore: updated logs permissions

### DIFF
--- a/aws-iam-policies/domain-protect-deploy.json
+++ b/aws-iam-policies/domain-protect-deploy.json
@@ -184,6 +184,7 @@
         "logs:DeleteRetentionPolicy",
         "logs:DescribeLogGroups",
         "logs:DisassociateKmsKey",
+        "logs:ListTagsForResource",
         "logs:ListTagsLogGroup",
         "logs:PutRetentionPolicy",
         "logs:TagLogGroup",
@@ -191,7 +192,7 @@
       ],
       "Resource": [
         "arn:aws:logs:eu-west-1:SECURITY_AWS_ACCOUNT_ID:log-group::log-stream:",
-        "arn:aws:logs:eu-west-1:SECURITY_AWS_ACCOUNT_ID:log-group:/aws/vendedlogs/states/*:log-stream:"
+        "arn:aws:logs:eu-west-1:SECURITY_AWS_ACCOUNT_ID:log-group:/aws/vendedlogs/states/*"
       ]
     }
   ]


### PR DESCRIPTION
## what
Updated logs permissions in `domain-protect-deploy` policy

## why
- failures in GitHub Actions builds due to permissions issues
- most likely due to changes made by AWS
