### PR TITLE
docs: correct formatting and image refs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,5 +10,3 @@ How Domain Protect scans all AWS accounts in Organization:
 ![Alt text](assets/images/multi-account.png?raw=true "Multi account setup")
 
 Components are detailed in the [takeover event flow table](automated-takeover.md)
-
-[back to README](../README.md)

--- a/docs/automated-takeover.md
+++ b/docs/automated-takeover.md
@@ -3,22 +3,16 @@
 * take over vulnerable subdomains yourself before attackers and bug bounty researchers
 * automated takeover with resources created in security account
 
-<kbd>
-  <img src="assets/images/takeover.png" width="500">
-</kbd>
+![Alt text](assets/images/takeover.png?raw=true "Friendly takeover")
 
 ## Slack messages
 * notification of takeover success or failure:
 
-<kbd>
-  <img src="assets/images/takeover-notification.png" width="500">
-</kbd>
+![Alt text](assets/images/takeover-notification.png?raw=true "Slack notification")
 
 * daily report of resources in security account:
 
-<kbd>
-  <img src="assets/images/resources-notification.png" width="500">
-</kbd>
+![Alt text](assets/images/resources-notification.png?raw=true "Resources report")
 
 ## supported resource types
 * Elastic Beanstalk environments
@@ -88,6 +82,7 @@ Example takeover event flow:
 
 ## Adding takeover feature to existing deployment
 If you have previously deployed a detection only environment:
+
 * add the `cloudfront:ListDistributions` permission to the [audit policy](../aws-iam-policies/domain-protect-audit.json) in every account
 * update line 59 of the [domain-protect-deploy policy](../aws-iam-policies/domain-protect-deploy.json) in security account
 * ensure your production Terraform workspace is `prd`
@@ -96,6 +91,7 @@ If you have previously deployed a detection only environment:
 
 ## Service Control Policies
 Ensure AWS Organization Service Control Policies applied to security account allow:
+
 * creation of takeover resources, i.e. S3 buckets and Elastic Beanstalk environments
 * all regions used by any other AWS account in the Organization
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,8 +1,6 @@
 # Database
 
-<kbd>
-  <img src="assets/images/database.png">
-</kbd>
+![Alt text](assets/images/database.png?raw=true "Domain Protect database")
 
 * Vulnerability Database uses DynamoDB
 * Lambda function `domain-protect-scan-prd` queries database to see if a vulnerability is already known

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,12 @@
 Published as a public [Terraform registry module](https://registry.terraform.io/modules/domain-protect/domain-protect/aws/latest)
 
 
-## Prevent subdomain takeover ...
+Prevent subdomain takeover ...
+
 ![Alt text](assets/images/slack-webhook-notifications.png?raw=true "Domain Protect architecture")
 
-## ... with serverless cloud infrastructure
+ ... with serverless cloud infrastructure
+
 ![Alt text](assets/images/domain-protect.png?raw=true "Domain Protect architecture")
 
 ## OWASP Global AppSec Dublin - talk and demo

--- a/docs/manual-aws-scans.md
+++ b/docs/manual-aws-scans.md
@@ -1,5 +1,6 @@
 # domain-protect manual scans
 scans Amazon Route53 to detect:
+
 * Alias records for CloudFront distributions with missing S3 origin
 * CNAME records for CloudFront distributions with missing S3 origin
 * ElasticBeanstalk Alias records vulnerable to takeover

--- a/docs/manual-cf-scans.md
+++ b/docs/manual-cf-scans.md
@@ -1,5 +1,6 @@
 # domain-protect Cloudflare manual scans
 scans Cloudflare to detect:
+
 * Subdomain NS delegations vulnerable to takeover
 * Subdomains pointing to missing storage buckets
 * Vulnerable CNAME records
@@ -46,14 +47,14 @@ python manual_scans/cloudflare/cf-ns.py
 ```
 
 ## subdomains pointing to missing storage buckets
-<img src="assets/images/cf/cf-storage.png" width="400">
+![Alt text](assets/images/cf/cf-storage.png?raw=true "Vulnerable CloudFlare storage")
 
 ```
 python manual_scans/cloudflare/cf-storage.py
 ```
 
 ## vulnerable CNAMEs
-<img src="assets/images/cf/cf-cname.png" width="400">
+![Alt text](assets/images/cf/cf-cname.png?raw=true "Vulnerable CloudFlare CNAME")
 
 ```
 python manual_scans/cloudflare/cf-cname.py

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -5,20 +5,15 @@ Domain protect generates the following regular reports, in addition to notificat
 ## Current Vulnerabilities (Daily)
 This daily report sends a message to Slack listing the currently known vulnerable domains that require fixes.  To change the frequency of this report from the default 24 hours, use the `reports_schedule` Terraform variable
 
-<kbd>
-  <img src="assets/images/current.png" width="600" alt="Current vulnerabilities example">
-</kbd>
+![Alt text](assets/images/current.png?raw=true "Current vulnerabilities example")
 
 ## Takeover Resources (Daily)
 This daily report lists the resources that are currently being used to prevent domain takeover.  This can be useful for managing costs associated with having the resources running.  To change the frequency of this report from the default 24 hours, use the `reports_schedule` Terraform variable
 
-<kbd>
-  <img src="assets/images/resources-notification.png" width="600" alt="Current resources example">
-</kbd>
+
+![Alt text](assets/images/resources-notification.png?raw=true "Current resources example")
 
 ## Stats (Monthly)
 This monthly report runs on the first of each month and lists number of domains takeovers that have been prevented in the last month, the current calendar year, and all time.  To change the frequency of this report from the default value, use the `stats_schedule` Terraform variable
 
-<kbd>
-  <img src="assets/images/stats.png" width="350" alt="Current resources example">
-</kbd>
+![Alt text](assets/images/stats.png?raw=true "Monthly statistics")


### PR DESCRIPTION
## what
- extra line before bullet points for correct formatting within mkdocs
- change image source reference for correct formatting within mkdocs

## why
- display text and images correctly in documentation
