### PR TITLE
docs: image reference updates

### DIFF
--- a/docs/a-records.md
+++ b/docs/a-records.md
@@ -8,9 +8,9 @@
   * Global Accelerator IP addresses
 * automated takeover not supported
 
-<img src="assets/images/a-record-vulnerable.png" width="400">
+![Alt text](assets/images/a-record-vulnerable.png?raw=true "Vulnerable A Record")
 
-<img src="assets/images/a-record-fixed.png" width="400">
+![Alt text](assets/images/a-record-fixed.png?raw=true "Fixed A Record")
 
 ## How an A record becomes vulnerable
 A records pointing to an IPv4 address can be vulnerable to subdomain takeover:
@@ -43,7 +43,7 @@ If A record points to legitimate IP address, e.g. in a service provider's AWS ac
 * create Account field with text starting `IP OK`
 * item must be manually removed when resource is decommissioned
 
-<img src="assets/images/ip-exception.png" width="400">
+![Alt text](assets/images/ip-exception.png?raw=true "IP Address exception")
 
 ## Enabling A record feature
 * set Terraform variable in your CI/CD pipeline or tfvars file:

--- a/docs/automated-takeover.md
+++ b/docs/automated-takeover.md
@@ -1,5 +1,6 @@
 # Automated takeover
 *optional feature turned on by default in production*
+
 * take over vulnerable subdomains yourself before attackers and bug bounty researchers
 * automated takeover with resources created in security account
 
@@ -29,6 +30,7 @@
 
 ## Deleting takeover resources
 To minimise costs these tasks should be done as quickly as possible:
+
 * fix the vulnerability by correcting DNS
 * in the case of S3, empty the S3 bucket manually via the console
 * delete the CloudFormation stack manually via the console
@@ -43,6 +45,7 @@ To minimise costs these tasks should be done as quickly as possible:
 
 ## automated takeover components
 Automated takeover components:
+
 * takeover Lambda - takes over vulnerable domains by creating resources
 * resources Lambda - reports on takeover resources in security account
 

--- a/docs/slack-webhook.md
+++ b/docs/slack-webhook.md
@@ -11,34 +11,34 @@ If using a Slack app, to ensure correct formatting set Terraform variable `slack
 
 * in your Slack client menu panel, select More, Apps, App Directory, Build
 
-<img src="assets/images/slack-create-app.png" width="400">
+![Alt text](assets/images/slack-create-app.png?raw=true "Create Slack app")
 
 * press Create an app
 * choose From scratch
 * name App `Domain Protect`
 * choose Slack Workspace for your organisation
 
-<img src="assets/images/slack-name-workspace.png" width="400">
+![Alt text](assets/images/slack-name-workspace.png?raw=true "Slack app name and workspace")
 
 * press Create App
 * select Incoming Webhooks
 
-<img src="assets/images/slack-activate-webhook.png" width="400">
+![Alt text](assets/images/slack-activate-webhook.png?raw=true "Activate Slack webhook")
 
 * move slider to On
 * press Add New Webhook to Workspace
 
-<img src="assets/images/slack-allow-access.png" width="400">
+![Alt text](assets/images/slack-allow-access.png?raw=true "Allow Slack access")
 
 * select channel
 * press Allow
 
-<img src="assets/images/slack-webhook-url.png" width="400">
+![Alt text](assets/images/slack-webhook-url.png?raw=true "Slack webhook URL")
 
 * copy webhook URL to a safe location
 * you'll see Domain Protect in Your Apps
 
-<img src="assets/images/slack-your-apps.png" width="400">
+![Alt text](assets/images/slack-your-apps.png?raw=true "Your Slack apps")
 
 * select the Domain Protect app
 * scroll down to Display Information
@@ -46,7 +46,7 @@ If using a Slack app, to ensure correct formatting set Terraform variable `slack
 * add the Domain Protect Slack [App Icon](./assets/slack/domain-protect-icon.png) from this repository
 * for background color enter `#2c2d30`
 
-<img src="assets/images/slack-app-display.png" width="400">
+![Alt text](assets/images/slack-app-display.png?raw=true "Slack app display information")
 
 * save changes
 
@@ -55,11 +55,11 @@ If using a Slack app, to ensure correct formatting set Terraform variable `slack
 * each channel needs its own app and webhook URL
 * app names do not have to be unique
 
-<img src="assets/images/slack-extra-channel.png" width="400">
+![Alt text](assets/images/slack-extra-channel.png?raw=true "Extra Slack channel")
 
 * all apps can be seen in Your Apps
 
-<img src="assets/images/slack-your-apps-2.png" width="400">
+![Alt text](assets/images/slack-your-apps-2.png?raw=true "Your Slack apps")
 
 ## Legacy Slack webhook (not recommended)
 


### PR DESCRIPTION
## what
- move to markdown format for image references to be compatible with `mkdocs`

## why
- ensure images displayed correctly on web site
