### PR TITLE
tests: run dev workflow on any push

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,8 +7,6 @@ on:
       - "**/*.tf"
       - "**/*.txt"
       - ".github/workflows/dev.yml"
-    branches:
-      - main
 
 env:
   TERRAFORM_VERSION: "1.7.3"


### PR DESCRIPTION
## what
- run the dev workflow for all branches
- this will allow integration tests (deployment) to be required for pull requests


## why
- improved testing
- greater confidence that a PR will not break Domain Protect, if it passes the integration tests
- should be OK from a security perspective as the workflow runs in a protected GitHub environment requiring approval
