### PR TITLE
fix: remove deprecated argument from aws_iam_role

### DIFF
--- a/modules/iam/data.tf
+++ b/modules/iam/data.tf
@@ -1,11 +1,6 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy" "default" {
-  for_each = var.takeover ? toset([
-    "AdministratorAccess-AWSElasticBeanstalk",
-    "AWSCloudFormationFullAccess",
-    "AmazonS3FullAccess",
-    "AmazonVPCFullAccess",
-  ]) : toset([])
-  name = each.value
+  for_each = var.takeover ? toset(var.managed_policy_names) : toset([])
+  name     = each.value
 }

--- a/modules/iam/data.tf
+++ b/modules/iam/data.tf
@@ -1,1 +1,11 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy" "default" {
+  for_each = toset([
+    "AdministratorAccess-AWSElasticBeanstalk",
+    "AWSCloudFormationFullAccess",
+    "AmazonS3FullAccess",
+    "AmazonVPCFullAccess", 
+  ])
+  name = each.value
+}

--- a/modules/iam/data.tf
+++ b/modules/iam/data.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy" "default" {
     "AdministratorAccess-AWSElasticBeanstalk",
     "AWSCloudFormationFullAccess",
     "AmazonS3FullAccess",
-    "AmazonVPCFullAccess", 
+    "AmazonVPCFullAccess",
   ]) : toset([])
   name = each.value
 }

--- a/modules/iam/data.tf
+++ b/modules/iam/data.tf
@@ -1,11 +1,11 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy" "default" {
-  for_each = toset([
+  for_each = var.takeover ? toset([
     "AdministratorAccess-AWSElasticBeanstalk",
     "AWSCloudFormationFullAccess",
     "AmazonS3FullAccess",
     "AmazonVPCFullAccess", 
-  ])
+  ]) : toset([])
   name = each.value
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,8 +1,18 @@
 resource "aws_iam_role" "lambda" {
   name                 = "${var.project}-${var.takeover ? "takeover" : var.role_name == "policyname" ? var.policy : var.role_name}-${var.environment}"
   assume_role_policy   = templatefile("${path.module}/templates/${var.assume_role_policy}_role.json.tpl", { project = var.project })
-  managed_policy_arns  = var.takeover ? ["arn:aws:iam::aws:policy/AmazonVPCFullAccess", "arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"] : []
   permissions_boundary = var.permissions_boundary_arn
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  for_each = var.takeover ? toset([
+    "arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk",
+    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess",
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/AmazonVPCFullAccess", 
+  ]) : toset([])
+  role       = aws_iam_role.lambda.name
+  policy_arn = each.value
 }
 
 resource "aws_iam_role_policy" "lambda" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -5,12 +5,7 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  for_each = var.takeover ? toset([
-    "arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk",
-    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess",
-    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-    "arn:aws:iam::aws:policy/AmazonVPCFullAccess", 
-  ]) : toset([])
+  for_each = var.takeover ? toset(data.aws_iam_policy.default.*.arn) : toset([])
   role       = aws_iam_role.lambda.name
   policy_arn = each.value
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  for_each   = var.takeover ? toset([for policy in data.aws_iam_policy.default: policy.arn]) : toset([])
+  for_each   = var.takeover ? toset([for policy in data.aws_iam_policy.default : policy.arn]) : toset([])
   role       = aws_iam_role.lambda.name
   policy_arn = each.value
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  for_each = var.takeover ? toset(data.aws_iam_policy.default.*.arn) : toset([])
+  for_each   = var.takeover ? toset(data.aws_iam_policy.default.*.arn) : toset([])
   role       = aws_iam_role.lambda.name
   policy_arn = each.value
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  for_each   = var.takeover ? toset(data.aws_iam_policy.default.*.arn) : toset([])
+  for_each   = var.takeover ? toset([for policy in data.aws_iam_policy.default: policy.arn]) : toset([])
   role       = aws_iam_role.lambda.name
   policy_arn = each.value
 }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -18,6 +18,16 @@ variable "policy" {
   default     = "lambda"
 }
 
+variable "managed_policy_names" {
+  description = "Managed policy names to attach to the IAM role"
+  default = [
+    "AdministratorAccess-AWSElasticBeanstalk",
+    "AWSCloudFormationFullAccess",
+    "AmazonS3FullAccess",
+    "AmazonVPCFullAccess",
+  ]
+}
+
 variable "takeover" {
   description = "include managed policies to enable takeover"
   default     = false


### PR DESCRIPTION
## what
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- fix: remove deprecated argument from aws_iam_role

## why
<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Preserve module for future versions of the terraform aws provider

> The managed_policy_arns argument is deprecated. Use the [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) resource instead. If Terraform should exclusively manage all managed policy attachments (the current behavior of this argument), use the [aws_iam_role_policy_attachments_exclusive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) resource as well.

## references
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes https://github.com/domain-protect/terraform-aws-domain-protect/issues/172
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#example-of-exclusive-managed-policies
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment