### PR TITLE
Check Python versions match

### DIFF
--- a/scripts/lambda-build/create-package-for-each.sh
+++ b/scripts/lambda-build/create-package-for-each.sh
@@ -2,6 +2,21 @@
 
 echo "Executing create_package.sh..."
 
+# Check Python version matches runtime
+python_minor_version="$(python3 --version)"
+python_version="${python_minor_version%.*}"
+prefix="Python "
+local_version="${python_version#$prefix}"
+runtime_prefix="python"
+lambda_version="${runtime#$runtime_prefix}"
+
+if [ "$lambda_version" != "$local_version" ]; then
+  echo "Error: local Python version does not match Lambda Python runtime"
+  echo "Local Python version: $local_version"
+  echo "Lambda Python version: $lambda_version"
+  exit 1
+fi
+
 function_list=${function_names//:/ }
 
 for i in $function_list

--- a/scripts/lambda-build/create-package.sh
+++ b/scripts/lambda-build/create-package.sh
@@ -2,6 +2,21 @@
 
 echo "Executing create_package.sh..."
 
+# Check Python version matches runtime
+python_minor_version="$(python3 --version)"
+python_version="${python_minor_version%.*}"
+prefix="Python "
+local_version="${python_version#$prefix}"
+runtime_prefix="python"
+lambda_version="${runtime#$runtime_prefix}"
+
+if [ "$lambda_version" != "$local_version" ]; then
+  echo "Error: local Python version does not match Lambda Python runtime"
+  echo "Local Python version: $local_version"
+  echo "Lambda Python version: $lambda_version"
+  exit 1
+fi
+
 dir_name=lambda_dist_pkg_$function_name/
 mkdir -p $path_cwd/build/$dir_name
 


### PR DESCRIPTION
## what
- check Python versions of the build runner / laptop match the version specified for the Lambda function
- exit build if there's a mismatch

## why
- identify mismatch before deploying functions
- save time troubleshooting
- this is a common scenario as it's an easy mistake to make
