### PR TITLE
Fix/eb takeover issue

### DIFF
--- a/lambda_code/takeover/eb-vpc.yaml
+++ b/lambda_code/takeover/eb-vpc.yaml
@@ -158,6 +158,9 @@ Resources:
       - Namespace: aws:autoscaling:launchconfiguration
         OptionName: SecurityGroups
         Value: !Ref HTTPIngressSecurityGroup
+      - Namespace: aws:autoscaling:launchconfiguration
+        aws:autoscaling:launchconfiguration:
+          DisableIMDSv1: true
       - Namespace: aws:ec2:vpc
         OptionName: VPCId
         Value: !Ref VPC

--- a/lambda_code/takeover/eb-vpc.yaml
+++ b/lambda_code/takeover/eb-vpc.yaml
@@ -159,8 +159,8 @@ Resources:
         OptionName: SecurityGroups
         Value: !Ref HTTPIngressSecurityGroup
       - Namespace: aws:autoscaling:launchconfiguration
-        aws:autoscaling:launchconfiguration:
-          DisableIMDSv1: true
+        OptionName: DisableIMDSv1
+        Value: 'true'
       - Namespace: aws:ec2:vpc
         OptionName: VPCId
         Value: !Ref VPC


### PR DESCRIPTION
## what
Specifically disable IMDSv1 in takeover Elastic Beanstalk

## why
Elastic Beanstalk takeover can fail with this error, disabling IMDSv1 should fix this according to reference below.
```
Resource handler returned message: "The Launch Configuration creation operation is not available in your account. Use launch templates to create configuration templates for your Auto Scaling groups.
```

## references
https://repost.aws/questions/QUcX9TipxqSGeM5G7RORmqoQ/new-account-recently-created-unable-to-create-environments-on-elastic-beanstalk-launch-configuration-error