### PR TITLE
Disable HackerOne as program expired

### DIFF
--- a/examples/prd/main.tf
+++ b/examples/prd/main.tf
@@ -9,7 +9,7 @@ module "domain_protect" {
   cloudflare_email    = var.cloudflare_email
   environment         = "prd"
   external_id         = var.external_id
-  hackerone           = "enabled"
+  hackerone           = "disabled"
   ip_address          = true
   ip_scan_schedule    = "10 minutes"
   ip_time_limit       = 0.1 # 6 minutes


### PR DESCRIPTION
## what
- disable HackerOne in production

## why
- API token no longer working
- Bug Bounty program set up by HackerOne for OWASP test purposes needs resetting / updating 