### PR TITLE
Reduce GitHub Actions permissions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: write
+      contents: read
       pull-requests: write
       checks: write
     steps:

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -27,7 +27,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: write
+      contents: read
       pull-requests: write
       checks: write
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
   pages: write
 


### PR DESCRIPTION
## what
- reduce excessive GitHub Actions permissions

## why
- reduce risk
- improve openSSF score

