### PR TITLE
Update domain-protect-deploy.json

### DIFF
--- a/aws-iam-policies/domain-protect-deploy.json
+++ b/aws-iam-policies/domain-protect-deploy.json
@@ -200,6 +200,13 @@
     {
       "Effect": "Allow",
       "Action": [
+          "states:ValidateStateMachineDefinition"
+      ],
+      "Resource": "arn:aws:states:eu-west-1:SECURITY_AWS_ACCOUNT_ID:stateMachine:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "logs:AssociateKmsKey",
         "logs:CreateLogGroup",
         "logs:DeleteLogGroup",


### PR DESCRIPTION
## what
Updated the domain-protect-deploy.json role to add the `states:ValidateStateMachineDefinition` permission


## why
When deploying for the first time, terraform fails to apply changes without the above action permission applied to the deploy role in AWS


## references
 Error: validating Step Functions State Machine definition: operation error SFN: ValidateStateMachineDefinition
