### PR TITLE
Option not to install audit role in Org Management account

### DIFF
--- a/docs/org-management.md
+++ b/docs/org-management.md
@@ -1,0 +1,23 @@
+# Organization Management Acccount
+
+There are two options for setting up Domain Protect with the Org Management account:
+
+## No new resources in Org Management account (Standard approach)
+
+AWS best practice is to have as few resources as possible within the Organization Management account, and to have the minimum possible users and roles with access to it.
+
+In line with this, the recommended approach for Domain Protect installation is:
+
+* install Domain Protect in a dedicated security tooling AWS account
+* don't create the [Domain Protect audit role](https://github.com/domain-protect/terraform-aws-domain-protect/blob/main/aws-iam-policies/domain-protect-audit.json) in the Org Management account
+* delegate an Organization service, e.g. Cloud Formation Stack Sets, to the security tooling account
+* this allows Domain Protect to list all AWS accounts in the organisation, essential for correct operation of Domain Protect
+
+## Domain Protect audit role in Org Management account (Alternative approach)
+
+The [Domain Protect audit role](https://github.com/domain-protect/terraform-aws-domain-protect/blob/main/aws-iam-policies/domain-protect-audit.json) can be implemented in the Org Management account, which may be appropriate in either of these scenarios:
+
+* Route 53 domains or hosted zones present in Org Management account
+* There is a preference not to delegate Organization services to other accounts
+
+If present, Domain Protect will assume the role in the Org Management account, and use this role both to list all accounts, and to test for domains vulnerable to takeover.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -19,6 +19,7 @@ In order to deploy Domain Protect successfully, it is necessary to meet the requ
 * Set [trust policy](https://github.com/domain-protect/terraform-aws-domain-protect/blob/main/aws-iam-policies/domain-protect-audit-trust-external-id.json) with Security Audit AWS Account ID
 * Use External ID in trust policy
 * Deploy across  Organization using [CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html)
+* See [Org Management Account](org-management.md) for considerations on installling domain protect audit role in the management account.
 
 ## Requirements for takeover
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Installation:
     - Requirements: requirements.md
     - Installation: installation.md
+    - Org management account: org-management.md
     - Migration: migration.md
     - Slack: slack.md
     - Slack Webhooks (legacy): slack-webhook.md

--- a/modules/iam/templates/accounts_policy.json.tpl
+++ b/modules/iam/templates/accounts_policy.json.tpl
@@ -61,6 +61,14 @@
       "Resource": "${ddb_table_arn}"
     },
     {
+      "Sid": "Organizations",
+      "Effect": "Allow",
+      "Action": [
+        "organizations:ListAccounts"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "StartStateMachine",
       "Effect": "Allow",
       "Action": [

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -82,7 +82,7 @@ def list_aws_accounts(client):
 
         return accounts_list
 
-    except Exception:
+    except exceptions.ClientError:
         logging.exception("ERROR: Unable to list AWS accounts across organization")
 
     return []
@@ -95,7 +95,7 @@ def list_accounts():
     try:
         return list_aws_accounts(client)
 
-    except Exception:
+    except exceptions.ClientError:
         logging.info(
             "Unable to list AWS accounts in org from this account, trying to assume role in management account %s",
             org_primary_account,

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -68,12 +68,7 @@ def assume_role(account, region_override="None"):
         return None
 
 
-def list_accounts():
-    org_primary_account = os.environ["ORG_PRIMARY_ACCOUNT"]
-
-    boto3_session = assume_role(org_primary_account)
-    client = boto3_session.client(service_name="organizations")
-
+def list_aws_accounts(client):
     accounts_list = []
 
     try:
@@ -88,12 +83,32 @@ def list_accounts():
         return accounts_list
 
     except Exception:
-        logging.exception(
-            "ERROR: Unable to list AWS accounts across organization with primary account %a",
+        logging.exception("ERROR: Unable to list AWS accounts across organization")
+
+    return []
+
+
+def list_accounts():
+    org_primary_account = os.environ["ORG_PRIMARY_ACCOUNT"]
+
+    client = boto3.client("organizations")
+    try:
+        return list_aws_accounts(client)
+
+    except Exception:
+        logging.info(
+            "Unable to list AWS accounts in org from this account, trying to assume role in management account %s",
             org_primary_account,
         )
 
-    return []
+    boto3_session = assume_role(org_primary_account)
+    if boto3_session is None:
+        logging.error("Failed to assume role in management account %s", org_primary_account)
+        return []
+
+    client = boto3_session.client("organizations")
+
+    return list_aws_accounts(client)
 
 
 def list_hosted_zones(account):

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -82,7 +82,7 @@ def list_aws_accounts(client):
 
         return accounts_list
 
-    except exceptions.ClientError:
+    except Exception:
         logging.info("Unable to list AWS accounts across organization from this account")
 
     return []

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -92,14 +92,12 @@ def list_accounts():
     org_primary_account = os.environ["ORG_PRIMARY_ACCOUNT"]
 
     client = boto3.client("organizations")
-    try:
-        return list_aws_accounts(client)
 
-    except exceptions.ClientError:
-        logging.info(
-            "Unable to list AWS accounts in org from this account, trying to assume role in management account %s",
-            org_primary_account,
-        )
+    accounts = list_aws_accounts(client)
+
+    if accounts:
+        logging.info("Listed %s AWS accounts in organization from this account", len(accounts))
+        return accounts
 
     boto3_session = assume_role(org_primary_account)
     if boto3_session is None:

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -83,7 +83,7 @@ def list_aws_accounts(client):
         return accounts_list
 
     except exceptions.ClientError:
-        logging.exception("ERROR: Unable to list AWS accounts across organization")
+        logging.info("Unable to list AWS accounts across organization from this account")
 
     return []
 


### PR DESCRIPTION
## what
- Option not to install Domain Protect audit role in Org Management account

## why
- AWS best security practice is to minimise resources and access to Org Management account

