### PR TITLE
Add DNS check to A record scan to eliminate false positives when zone is not authoritative

### DIFF
--- a/docs/a-records.md
+++ b/docs/a-records.md
@@ -69,7 +69,7 @@ To minimise false positive alerts:
 
 * monitor Slack channel
 * assess which IP addresses are legitimate
-* immediately after deploying, [record IP address as OK](#record-ip-address-as-ok) for legitimate addresses
+* immediately after deploying, add approved addresses to `aws_ip_addresses` Terraform variable
 * complete before DynamoDB `DomainProtectIPsPrd` item count updates from initial value of `0`
 
 ## Optimising cost and performance

--- a/lambda_code/scan_ips/requirements.txt
+++ b/lambda_code/scan_ips/requirements.txt
@@ -1,1 +1,2 @@
+dnspython==2.8.0
 requests==2.32.5

--- a/lambda_code/scan_ips/scan_ips.py
+++ b/lambda_code/scan_ips/scan_ips.py
@@ -17,6 +17,7 @@ from utils.utils_db import db_vulnerability_found
 from utils.utils_db_ips import db_count_items
 from utils.utils_db_ips import db_get_ip_table_name
 from utils.utils_db_ips import db_ip
+from utils.utils_dns import dns_deleted
 from utils.utils_hackerone import hackerone_create_report
 from utils.utils_requests import get_all_aws_ips
 from utils.utils_sanitise import restore_wildcard
@@ -109,6 +110,10 @@ def a_record(account_name, record_sets, prefixes):
         domain = record["Name"]
         domain = restore_wildcard(domain)
         print(f"checking if {domain} is vulnerable to takeover")
+
+        if dns_deleted(domain):
+            print(f"hosted zone not authoritative")
+            return
 
         ip_addresses = [r["Value"] for r in record["ResourceRecords"]]
 


### PR DESCRIPTION
## what
add DNS check to A record scan to eliminate false positive vulnerabilities, in the case that the hosted zone is not authoritative

## why
eliminate false positives, as the record is not vulnerable in this case

## references
fixes https://github.com/domain-protect/terraform-aws-domain-protect/issues/370
