### PR TITLE
Add support for AWS GameLift IP addresses

### DIFF
--- a/aws-iam-policies/domain-protect-audit.json
+++ b/aws-iam-policies/domain-protect-audit.json
@@ -26,12 +26,12 @@
         "ecs:DescribeTasks",
         "ecs:ListClusters",
         "ecs:ListTasks",
-        "globalaccelerator:ListAccelerators",
-        "lightsail:GetInstances",
-        "lightsail:GetStaticIps",
         "gamelift:ListCompute",
         "gamelift:ListContainerFleets",
-        "gamelift:ListFleets"
+        "gamelift:ListFleets",
+        "globalaccelerator:ListAccelerators",
+        "lightsail:GetInstances",
+        "lightsail:GetStaticIps"
       ]
     }
   ]

--- a/aws-iam-policies/domain-protect-audit.json
+++ b/aws-iam-policies/domain-protect-audit.json
@@ -28,7 +28,10 @@
         "ecs:ListTasks",
         "globalaccelerator:ListAccelerators",
         "lightsail:GetInstances",
-        "lightsail:GetStaticIps"
+        "lightsail:GetStaticIps",
+        "gamelift:ListCompute",
+        "gamelift:ListContainerFleets",
+        "gamelift:ListFleets"
       ]
     }
   ]

--- a/docs/a-records.md
+++ b/docs/a-records.md
@@ -5,6 +5,8 @@
   * Elastic IP addresses
   * EC2 instances with public IP addresses
   * ECS Fargate public IP addresses
+  * GameLift Fleet IP addresses
+  * GameLift Container Fleet IP addresses
   * Global Accelerator IP addresses
   * Lightsail instance public IP addresses
   * Lightsail static IP addresses

--- a/lambda_code/scan_ips/scan_ips.py
+++ b/lambda_code/scan_ips/scan_ips.py
@@ -9,6 +9,8 @@ from utils.utils_aws_ips import get_accelerator_addresses
 from utils.utils_aws_ips import get_ec2_addresses
 from utils.utils_aws_ips import get_ecs_addresses
 from utils.utils_aws_ips import get_eip_addresses
+from utils.utils_aws_ips import get_gamelift_container_fleet_ips
+from utils.utils_aws_ips import get_gamelift_fleet_ips
 from utils.utils_aws_ips import get_lightsail_instance_addresses
 from utils.utils_aws_ips import get_lightsail_static_addresses
 from utils.utils_aws_ips import get_regions
@@ -150,6 +152,16 @@ def get_ips(account_id, account_name):
 
         for ecs_public_ip in ecs_public_ips:
             db_ip(ecs_public_ip, account_name, region, "ECS Public IP")
+
+        gamelift_container_fleet_ips = get_gamelift_container_fleet_ips(account_id, account_name, region)
+
+        for gamelift_container_fleet_ip in gamelift_container_fleet_ips:
+            db_ip(gamelift_container_fleet_ip, account_name, region, "GameLift Container Instance IP")
+
+        gamelift_fleet_ips = get_gamelift_fleet_ips(account_id, account_name, region)
+
+        for gamelift_fleet_ip in gamelift_fleet_ips:
+            db_ip(gamelift_fleet_ip, account_name, region, "GameLift Instance IP")
 
         lightsail_static_public_ips = get_lightsail_static_addresses(account_id, account_name, region)
 

--- a/modules/stackset/templates/domain_protect.json
+++ b/modules/stackset/templates/domain_protect.json
@@ -112,12 +112,12 @@
                 "ecs:DescribeTasks",
                 "ecs:ListClusters",
                 "ecs:ListTasks",
-                "globalaccelerator:ListAccelerators",
-                "lightsail:GetInstances",
-                "lightsail:GetStaticIps",
                 "gamelift:ListCompute",
                 "gamelift:ListContainerFleets",
-                "gamelift:ListFleets"
+                "gamelift:ListFleets",
+                "globalaccelerator:ListAccelerators",
+                "lightsail:GetInstances",
+                "lightsail:GetStaticIps"
               ]
             }
           ]

--- a/modules/stackset/templates/domain_protect.json
+++ b/modules/stackset/templates/domain_protect.json
@@ -114,7 +114,10 @@
                 "ecs:ListTasks",
                 "globalaccelerator:ListAccelerators",
                 "lightsail:GetInstances",
-                "lightsail:GetStaticIps"
+                "lightsail:GetStaticIps",
+                "gamelift:ListCompute",
+                "gamelift:ListContainerFleets",
+                "gamelift:ListFleets"
               ]
             }
           ]

--- a/utils/utils_aws_ips.py
+++ b/utils/utils_aws_ips.py
@@ -323,7 +323,7 @@ def get_gamelift_fleet_ips(account_id, account_name, region):
             pages = paginator.paginate()
             for page in pages:
                 for fleet_id in page["FleetIds"]:
-                    public_ips = get_gamelift_ips_by_fleet(boto3_session, account_name, fleet_id)
+                    public_ips = get_gamelift_ips_by_fleet(gamelift, account_name, fleet_id)
                     for public_ip in public_ips:
                         public_ip_list.append(public_ip)
 
@@ -354,7 +354,7 @@ def get_gamelift_container_fleet_ips(account_id, account_name, region):
             for page in pages:
                 for container_fleet in page["ContainerFleets"]:
                     container_fleet_id = container_fleet["FleetId"]
-                    public_ips = get_gamelift_ips_by_fleet(boto3_session, account_name, container_fleet_id)
+                    public_ips = get_gamelift_ips_by_fleet(gamelift, account_name, container_fleet_id)
                     for public_ip in public_ips:
                         public_ip_list.append(public_ip)
 
@@ -372,10 +372,8 @@ def get_gamelift_container_fleet_ips(account_id, account_name, region):
     return []
 
 
-def get_gamelift_ips_by_fleet(session, account_name, fleet_id):
+def get_gamelift_ips_by_fleet(gamelift, account_name, fleet_id):
     public_ips = []
-
-    gamelift = session.client("gamelift")
 
     try:
         paginator = gamelift.get_paginator("list_compute")
@@ -383,8 +381,9 @@ def get_gamelift_ips_by_fleet(session, account_name, fleet_id):
         for page in pages:
             print(page["ComputeList"])
             for compute in page["ComputeList"]:
-                public_ip = compute["IpAddress"]
-                public_ips.append(public_ip)
+                public_ip = compute.get("IpAddress")
+                if public_ip:
+                    public_ips.append(public_ip)
 
         return public_ips
 

--- a/utils/utils_aws_ips.py
+++ b/utils/utils_aws_ips.py
@@ -311,6 +311,92 @@ def get_ecs_addresses(account_id, account_name, region):
     return []
 
 
+def get_gamelift_fleet_ips(account_id, account_name, region):
+    try:
+        boto3_session = assume_role(account_id, region)
+        gamelift = boto3_session.client("gamelift")
+
+        public_ip_list = []
+
+        try:
+            paginator = gamelift.get_paginator("list_fleets")
+            pages = paginator.paginate()
+            for page in pages:
+                for fleet_id in page["FleetIds"]:
+                    public_ips = get_gamelift_ips_by_fleet(boto3_session, account_name, fleet_id)
+                    for public_ip in public_ips:
+                        public_ip_list.append(public_ip)
+
+            return public_ip_list
+
+        except Exception:
+            logging.error(
+                "ERROR: Lambda execution role requires gamelift:ListFleets permission in %a account",
+                account_name,
+            )
+
+    except (AttributeError, Exception):
+        logging.error("ERROR: unable to assume role in %a account %s", account_name, account_id)
+
+    return []
+
+
+def get_gamelift_container_fleet_ips(account_id, account_name, region):
+    try:
+        boto3_session = assume_role(account_id, region)
+        gamelift = boto3_session.client("gamelift")
+
+        public_ip_list = []
+
+        try:
+            paginator = gamelift.get_paginator("list_container_fleets")
+            pages = paginator.paginate()
+            for page in pages:
+                for container_fleet in page["ContainerFleets"]:
+                    container_fleet_id = container_fleet["FleetId"]
+                    public_ips = get_gamelift_ips_by_fleet(boto3_session, account_name, container_fleet_id)
+                    for public_ip in public_ips:
+                        public_ip_list.append(public_ip)
+
+            return public_ip_list
+
+        except Exception:
+            logging.error(
+                "ERROR: Lambda execution role requires gamelift:ListContainerFleets permission in %a account",
+                account_name,
+            )
+
+    except (AttributeError, Exception):
+        logging.error("ERROR: unable to assume role in %a account %s", account_name, account_id)
+
+    return []
+
+
+def get_gamelift_ips_by_fleet(session, account_name, fleet_id):
+    public_ips = []
+
+    gamelift = session.client("gamelift")
+
+    try:
+        paginator = gamelift.get_paginator("list_compute")
+        pages = paginator.paginate(FleetId=fleet_id)
+        for page in pages:
+            print(page["ComputeList"])
+            for compute in page["ComputeList"]:
+                public_ip = compute["IpAddress"]
+                public_ips.append(public_ip)
+
+        return public_ips
+
+    except Exception:
+        logging.error(
+            "ERROR: Lambda execution role requires gamelift:ListCompute permission in %a account",
+            account_name,
+        )
+
+    return []
+
+
 def get_lightsail_instance_addresses(account_id, account_name, region):
 
     try:


### PR DESCRIPTION
## what
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Adds A record support for AWS GameLift (Managed fleets and Container fleets)


## why
<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- GameLift managed instances are not exposed to the user's AWS account and so need special handling to collect the IP address information.


## references
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- https://github.com/domain-protect/terraform-aws-domain-protect/issues/428
- boto3 references:
  - https://docs.aws.amazon.com/boto3/latest/reference/services/gamelift/client/list_container_fleets.html
  - https://docs.aws.amazon.com/boto3/latest/reference/services/gamelift/client/list_fleets.html
  - https://docs.aws.amazon.com/boto3/latest/reference/services/gamelift/client/list_compute.html
