### PR TITLE
(bug) Gracefully handle GameLift error in unsupported regions

### DIFF
--- a/utils/utils_aws_ips.py
+++ b/utils/utils_aws_ips.py
@@ -329,6 +329,13 @@ def get_gamelift_fleet_ips(account_id, account_name, region):
 
             return public_ip_list
 
+        except gamelift.exceptions.UnsupportedRegionException:
+            logging.info(
+                "INFO: GameLift not supported in %a region in %a account",
+                region,
+                account_name,
+            )
+
         except Exception:
             logging.error(
                 "ERROR: Lambda execution role requires gamelift:ListFleets permission in %a account",
@@ -359,6 +366,13 @@ def get_gamelift_container_fleet_ips(account_id, account_name, region):
                         public_ip_list.append(public_ip)
 
             return public_ip_list
+
+        except gamelift.exceptions.UnsupportedRegionException:
+            logging.info(
+                "INFO: GameLift Containers not supported in %a region in %a account",
+                region,
+                account_name,
+            )
 
         except Exception:
             logging.error(


### PR DESCRIPTION
## what
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- GameLift is not supported in all regions, adds handler to log with an INFO log instead of an error.

## why
<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- To handle the error gracefully and not display misleading errors

## references
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
